### PR TITLE
Disable Undefined Behavior Sanitizer - UBSAN

### DIFF
--- a/nvidia-UBSAN.patch
+++ b/nvidia-UBSAN.patch
@@ -1,0 +1,11 @@
+--- a/kernel/Kbuild
++++ b/kernel/Kbuild
+@@ -53,6 +53,8 @@
+ NV_UNDEF_BEHAVIOR_SANITIZER ?=
+ ifeq ($(NV_UNDEF_BEHAVIOR_SANITIZER),1)
+  UBSAN_SANITIZE := y
++else
++ UBSAN_SANITIZE := n
+ endif
+ 
+ $(foreach _module, $(NV_KERNEL_MODULES), \

--- a/xorg-x11-drv-nvidia-470xx.spec
+++ b/xorg-x11-drv-nvidia-470xx.spec
@@ -25,7 +25,7 @@
 Name:            xorg-x11-drv-%{_nvidia_serie}
 Epoch:           3
 Version:         470.239.06
-Release:         1%{?dist}
+Release:         2%{?dist}
 Summary:         NVIDIA's 470xx series proprietary display driver for NVIDIA graphic cards
 
 License:         Redistributable, no modification permitted
@@ -44,6 +44,8 @@ Source14:        nvidia-fallback.service
 Source15:        rhel_nvidia.conf
 Source16:        nvidia-power-management.conf
 Source17:        70-nvidia.preset
+
+Patch0:          nvidia-UBSAN.patch
 
 ExclusiveArch: x86_64 i686
 
@@ -208,6 +210,8 @@ sh %{SOURCE0} \
   --extract-only --target nvidiapkg-%{_target_cpu}
 ln -s nvidiapkg-%{_target_cpu} nvidiapkg
 
+cd nvidiapkg
+%patch -P0 -p1
 
 %build
 # Nothing to build
@@ -563,6 +567,9 @@ fi ||:
 %endif
 
 %changelog
+* Sun May 05 2024 Giannis Kapetanakis <bilias@edu.physics.uoc.gr> - 3:470.239.06-2
+- Disable Undefined Behavior Sanitizer - UBSAN for NVIDIA modules
+
 * Mon Apr 15 2024 Sérgio Basto <sergio@serjux.com> - 3:470.239.06-1
 - Update xorg-x11-drv-nvidia-470xx to 470.239.06
 


### PR DESCRIPTION
Fedora F40 in kernel 6.8.8 enabled UBSAN
https://www.kernel.org/doc/html/v4.19/dev-tools/ubsan.html
https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html
https://forums.developer.nvidia.com/t/ubsan-array-index-out-of-bounds-complaints-in-newer-kernels/271705

grep -w CONFIG_UBSAN /boot/config-6.8.*
/boot/config-6.8.7-300.fc40.x86_64:# CONFIG_UBSAN is not set
/boot/config-6.8.8-300.fc40.x86_64:CONFIG_UBSAN=y

This creates a trace with NVIDIA.
[dmesg.txt](https://github.com/rpmfusion/xorg-x11-drv-nvidia-470xx/files/15212307/dmesg.txt)
ie:
[   12.771544] UBSAN: array-index-out-of-bounds in /tmp/akmodsbuild.jZjipAB2/BUILD/nvidia-470xx-kmod-470.239.06/_kmod_build_6.8.8-300.fc40.x86_64/nvidia-uvm/uvm_pmm_gpu.c:2277:28
[   12.771546] index 0 is out of range for type 'uvm_gpu_chunk_t *[*]'
...

This patch explicitly disables UBSAN checks for nvidia modules in the Kbuild.
I've tried to disable it only for nvidia-uvm but didn't work. Didn't persist on it.

Ideally, the source code should be updated to convert structures to use C99 flexible array members.
See for instance a patch for a different driver but same problem here:
https://gist.github.com/joanbm/9cd5fda1dcfab9a67b42cc6195b7b269

Tested it with Fedora 40 and 6.8.8-300.fc40.x86_64 on GK106 [GeForce GTX 660]

Rebuild xorg-x11-drv-nvidia-470xx-470.239.06
Reinstall xorg-x11-drv-nvidia-470xx-kmodsrc
Rebuild akmod
akmods --kernels 6.8.8-300.fc40.x86_64 --rebuild

Trace gone.
